### PR TITLE
Add From<E> for ReadExactError<E>

### DIFF
--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -12,6 +12,12 @@ pub enum ReadExactError<E> {
     Other(E),
 }
 
+impl<E> From<E> for ReadExactError<E> {
+    fn from(err: E) -> Self {
+        ReadExactError::Other(err)
+    }
+}
+
 impl<E: fmt::Debug> fmt::Display for ReadExactError<E> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{:?}", self)


### PR DESCRIPTION
This makes it easier to propagate errors when using both normal IO functions and read_exact.

For example, you can do:
```rust
fn copy<R, W>(n: usize, source: R, dest: W) -> Result<(), ReadExactError<R::Error>> 
where 
     R: Read,
     W: Write + Io<Error = R::Error>
{
        let mut buf = vec![0; n];
        source.read_exact(&mut buf)?;
        Ok(dest.write_all(&buf)?)
}
```